### PR TITLE
docs: link to NS8 developer manual

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "terminal.integrated.env.linux": {
+        "NODE_OPTIONS": "--openssl-legacy-provider"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2,25 +2,4 @@
 
 This library includes [Vue.js](https://vuejs.org/) UI components and mixins used by [NethServer 8](https://github.com/NethServer/ns8-core) UI.
 
-In `src/main.js` add the following to globally include NS8 components:
-
-```js
-// main.js
-
-import ns8Lib from "@nethserver/ns8-ui-lib";
-Vue.use(ns8Lib);
-```
-
-To import a mixin inside a component (e.g. `TaskService` mixin):
-
-```js
-// ComponentName.vue
-
-import { TaskService } from "@nethserver/ns8-ui-lib";
-
-export default {
-  name: "ComponentName",
-  mixins: [TaskService],
-  ...
-}
-```
+Documentation of NS8 UI library can be found in [this section of the Developer manual](https://nethserver.github.io/ns8-core/ui/library/).


### PR DESCRIPTION
Add link to NS8 developer manual in README.md

Other changes:
- Set `--openssl-legacy-provider` to `NODE_OPTIONS` in vscode terminal env variable. This is needed when developing in Node v18 inside vscode container