### PR TITLE
Implement password checkComplexity check in NsPasswordInput.vue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nethserver/ns8-ui-lib",
-  "version": "0.1.27",
+  "version": "0.1.32",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nethserver/ns8-ui-lib",
-      "version": "0.1.27",
+      "version": "0.1.32",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@rollup/plugin-json": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nethserver/ns8-ui-lib",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "Vue.js library for NethServer 8 UI",
   "keywords": [
     "nethserver",

--- a/src/lib-components/NsPasswordInput.vue
+++ b/src/lib-components/NsPasswordInput.vue
@@ -26,9 +26,9 @@
           :class="[
             'requirement',
             {
-              'requirement-ok': isLengthOk && checkStrength,
+              'requirement-ok': isLengthOk && minLength !== 0,
               'requirement-light': light,
-              'requirement-disabled': disabled || !checkStrength,
+              'requirement-disabled': disabled || minLength === 0,
             },
           ]"
           >{{ lengthLabel }}</span
@@ -183,11 +183,7 @@ export default {
   },
   computed: {
     isLengthOk() {
-      if (!this.checkStrength) {
-        return true;
-      } else {
         return this.value.length >= this.minLength;
-      }
     },
     isLowercaseOk() {
       if (!this.checkStrength) {

--- a/src/lib-components/NsPasswordInput.vue
+++ b/src/lib-components/NsPasswordInput.vue
@@ -188,7 +188,7 @@ export default {
   },
   computed: {
     isLengthOk() {
-        return this.value.length >= this.minLength;
+      return this.value.length >= this.minLength;
     },
     isLowercaseOk() {
       if (!this.checkComplexity) {

--- a/src/lib-components/NsPasswordInput.vue
+++ b/src/lib-components/NsPasswordInput.vue
@@ -26,9 +26,9 @@
           :class="[
             'requirement',
             {
-              'requirement-ok': isLengthOk,
+              'requirement-ok': isLengthOk && checkStrength,
               'requirement-light': light,
-              'requirement-disabled': disabled,
+              'requirement-disabled': disabled || !checkStrength,
             },
           ]"
           >{{ lengthLabel }}</span
@@ -37,9 +37,9 @@
           :class="[
             'requirement',
             {
-              'requirement-ok': isLowercaseOk,
+              'requirement-ok': isLowercaseOk && checkStrength,
               'requirement-light': light,
-              'requirement-disabled': disabled,
+              'requirement-disabled': disabled || !checkStrength,
             },
           ]"
           >{{ lowercaseLabel }}</span
@@ -48,9 +48,9 @@
           :class="[
             'requirement',
             {
-              'requirement-ok': isUppercaseOk,
+              'requirement-ok': isUppercaseOk && checkStrength,
               'requirement-light': light,
-              'requirement-disabled': disabled,
+              'requirement-disabled': disabled || !checkStrength,
             },
           ]"
           >{{ uppercaseLabel }}</span
@@ -59,9 +59,9 @@
           :class="[
             'requirement',
             {
-              'requirement-ok': isNumberOk,
+              'requirement-ok': isNumberOk && checkStrength,
               'requirement-light': light,
-              'requirement-disabled': disabled,
+              'requirement-disabled': disabled || !checkStrength,
             },
           ]"
           >{{ numberLabel }}</span
@@ -70,9 +70,9 @@
           :class="[
             'requirement',
             {
-              'requirement-ok': isSymbolOk,
+              'requirement-ok': isSymbolOk && checkStrength,
               'requirement-light': light,
-              'requirement-disabled': disabled,
+              'requirement-disabled': disabled || !checkStrength,
             },
           ]"
           >{{ symbolLabel }}</span
@@ -138,6 +138,10 @@ export default {
       default: undefined,
     },
     light: Boolean,
+    checkStrength: {
+      type: Boolean,
+      default: true,
+    },
     minLength: {
       type: Number,
       default: 8,
@@ -179,19 +183,39 @@ export default {
   },
   computed: {
     isLengthOk() {
-      return this.value.length >= this.minLength;
+      if (!this.checkStrength) {
+        return true;
+      } else {
+        return this.value.length >= this.minLength;
+      }
     },
     isLowercaseOk() {
-      return /[a-z]/.test(this.value);
+      if (!this.checkStrength) {
+        return true;
+      } else {
+        return /[a-z]/.test(this.value);
+      }
     },
     isUppercaseOk() {
-      return /[A-Z]/.test(this.value);
+      if (!this.checkStrength) {
+        return true;
+      } else {
+        return /[A-Z]/.test(this.value);
+      }
     },
     isNumberOk() {
-      return /\d/.test(this.value);
+      if (!this.checkStrength) {
+        return true;
+      } else {
+        return /\d/.test(this.value);
+      }
     },
     isSymbolOk() {
-      return /\W|_/.test(this.value);
+      if (!this.checkStrength) {
+        return true;
+      } else {
+        return /\W|_/.test(this.value);
+      }
     },
     isEqualOk() {
       return this.value.length && this.value === this.confirmPassword;

--- a/src/lib-components/NsPasswordInput.vue
+++ b/src/lib-components/NsPasswordInput.vue
@@ -23,56 +23,61 @@
       </NsTextInput>
       <div class="password-meter">
         <span
+          v-if="minLength !== 0"
           :class="[
             'requirement',
             {
-              'requirement-ok': isLengthOk && minLength !== 0,
+              'requirement-ok': isLengthOk,
               'requirement-light': light,
-              'requirement-disabled': disabled || minLength === 0,
+              'requirement-disabled': disabled,
             },
           ]"
           >{{ lengthLabel }}</span
         >
         <span
+          v-if="checkComplexity"
           :class="[
             'requirement',
             {
-              'requirement-ok': isLowercaseOk && checkStrength,
+              'requirement-ok': isLowercaseOk,
               'requirement-light': light,
-              'requirement-disabled': disabled || !checkStrength,
+              'requirement-disabled': disabled,
             },
           ]"
           >{{ lowercaseLabel }}</span
         >
         <span
+          v-if="checkComplexity"
           :class="[
             'requirement',
             {
-              'requirement-ok': isUppercaseOk && checkStrength,
+              'requirement-ok': isUppercaseOk,
               'requirement-light': light,
-              'requirement-disabled': disabled || !checkStrength,
+              'requirement-disabled': disabled,
             },
           ]"
           >{{ uppercaseLabel }}</span
         >
         <span
+          v-if="checkComplexity"
           :class="[
             'requirement',
             {
-              'requirement-ok': isNumberOk && checkStrength,
+              'requirement-ok': isNumberOk,
               'requirement-light': light,
-              'requirement-disabled': disabled || !checkStrength,
+              'requirement-disabled': disabled,
             },
           ]"
           >{{ numberLabel }}</span
         >
         <span
+          v-if="checkComplexity"
           :class="[
             'requirement',
             {
-              'requirement-ok': isSymbolOk && checkStrength,
+              'requirement-ok': isSymbolOk,
               'requirement-light': light,
-              'requirement-disabled': disabled || !checkStrength,
+              'requirement-disabled': disabled,
             },
           ]"
           >{{ symbolLabel }}</span
@@ -138,7 +143,7 @@ export default {
       default: undefined,
     },
     light: Boolean,
-    checkStrength: {
+    checkComplexity: {
       type: Boolean,
       default: true,
     },
@@ -186,28 +191,28 @@ export default {
         return this.value.length >= this.minLength;
     },
     isLowercaseOk() {
-      if (!this.checkStrength) {
+      if (!this.checkComplexity) {
         return true;
       } else {
         return /[a-z]/.test(this.value);
       }
     },
     isUppercaseOk() {
-      if (!this.checkStrength) {
+      if (!this.checkComplexity) {
         return true;
       } else {
         return /[A-Z]/.test(this.value);
       }
     },
     isNumberOk() {
-      if (!this.checkStrength) {
+      if (!this.checkComplexity) {
         return true;
       } else {
         return /\d/.test(this.value);
       }
     },
     isSymbolOk() {
-      if (!this.checkStrength) {
+      if (!this.checkComplexity) {
         return true;
       } else {
         return /\W|_/.test(this.value);


### PR DESCRIPTION
This pull request adds a password strength check feature to the NsPasswordInput component in the src/lib-components/NsPasswordInput.vue file. The checkStrength prop is introduced to enable or disable the password strength check. When enabled, the component checks the password strength based on length, lowercase letters, uppercase letters, numbers, and symbols. When disabled, the component does not perform any password strength check.

- strength disabled
![image](https://github.com/NethServer/ns8-ui-lib/assets/3164851/296b7991-d670-4705-8206-eca12ffecfc0)
- strength enabled but complexity disabled
![image](https://github.com/NethServer/ns8-ui-lib/assets/3164851/cd16adaf-37e7-453b-97af-312ca9569540)
- strength enabled and complexity enabled
![image](https://github.com/NethServer/ns8-ui-lib/assets/3164851/589d3eee-a6a1-47a2-a815-69c86ca926e2)


- validation 
![Capture d’écran du 2024-02-20 14-50-55](https://github.com/NethServer/ns8-ui-lib/assets/3164851/60a72e5d-41a0-4053-be62-737b974c79ec)
![Capture d’écran du 2024-02-20 14-50-14](https://github.com/NethServer/ns8-ui-lib/assets/3164851/955cd19d-70db-4e90-a3d4-2dc3dfc1f9bf)
![Capture d’écran du 2024-02-20 14-49-15](https://github.com/NethServer/ns8-ui-lib/assets/3164851/32a62beb-ae5c-4f5a-a96e-6c00b16a50b5)


https://github.com/NethServer/dev/issues/6845