### PR TITLE
fix: style and timestamp of NsToastNotification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nethserver/ns8-ui-lib",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Vue.js library for NethServer 8 UI",
   "keywords": [
     "nethserver",

--- a/src/lib-components/NsToastNotification.vue
+++ b/src/lib-components/NsToastNotification.vue
@@ -95,7 +95,7 @@
           <cv-tooltip
             alignment="center"
             direction="bottom"
-            :tip="formatDate(timestamp, 'yyyy-MM-dd HH:mm:ss')"
+            :tip="formatDate(timestamp, 'Pp')"
           >
             {{
               formatDateDistance(timestamp, new Date(), {
@@ -240,7 +240,6 @@ export default {
 
 .notification-drawer .cv-notifiation.bx--toast-notification.notification {
   width: 100%;
-  cursor: pointer;
 }
 
 .notification-read {


### PR DESCRIPTION
- Use current locale to format notification timestamp
- Don't show `cursor-pointer` on notifications