### PR TITLE
fix: add mark.js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nethserver/ns8-ui-lib",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nethserver/ns8-ui-lib",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -26,6 +26,7 @@
         "@vue/cli-plugin-babel": "^4.5.10",
         "@vue/cli-service": "^4.5.10",
         "cross-env": "^7.0.3",
+        "mark.js": "^8.11.1",
         "minimist": "^1.2.5",
         "rollup": "^2.53.2",
         "rollup-plugin-terser": "^7.0.2",
@@ -8946,6 +8947,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
@@ -22474,6 +22482,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nethserver/ns8-ui-lib",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Vue.js library for NethServer 8 UI",
   "keywords": [
     "nethserver",
@@ -44,6 +44,7 @@
     "@vue/cli-plugin-babel": "^4.5.10",
     "@vue/cli-service": "^4.5.10",
     "cross-env": "^7.0.3",
+    "mark.js": "^8.11.1",
     "minimist": "^1.2.5",
     "rollup": "^2.53.2",
     "rollup-plugin-terser": "^7.0.2",


### PR DESCRIPTION
Include mark.js dependency in the package.json file. With this update, projects using ns8-ui-lib will no longer need to install mark.js separately.