### PR TITLE
feat(NsInlineNotification): add loadingAction prop for action button spinner

### DIFF
--- a/src/lib-components/NsInlineNotification.vue
+++ b/src/lib-components/NsInlineNotification.vue
@@ -51,22 +51,19 @@
         </p>
       </div>
     </div>
-    <button
+    <NsButton
       v-if="actionLabel"
       @click="$emit('action')"
-      :disabled="loadingAction"
+      :loading="loadingAction"
+      kind="ghost"
+      size="sm"
       :class="[
         `${carbonPrefix}--inline-notification__action-button`,
-        `${carbonPrefix}--btn`,
-        `${carbonPrefix}--btn--sm`,
-        `${carbonPrefix}--btn--ghost`,
         'action-button'
       ]"
-      type="button"
     >
-      <span v-if="loadingAction" class="action-button__loader"></span>
       {{ actionLabel }}
-    </button>
+    </NsButton>
     <button
       v-if="showCloseButton"
       type="button"
@@ -83,11 +80,12 @@
 <script>
 import { CvInlineNotification } from "@carbon/vue";
 import NsCircleTimer from "./NsCircleTimer.vue";
+import NsButton from "./NsButton.vue";
 
 export default {
   name: "NsInlineNotification",
   extends: CvInlineNotification,
-  components: { NsCircleTimer },
+  components: { NsCircleTimer, NsButton },
   props: {
     showCloseButton: {
       type: Boolean,
@@ -134,24 +132,6 @@ export default {
 
 .action-button {
   margin-right: 0.5rem;
-}
-
-.action-button__loader {
-  display: inline-block;
-  width: 0.875rem;
-  height: 0.875rem;
-  border: 2px solid currentColor;
-  border-top-color: transparent;
-  border-radius: 50%;
-  animation: ns-spin 0.6s linear infinite;
-  margin-right: 0.4rem;
-  vertical-align: middle;
-}
-
-@keyframes ns-spin {
-  to {
-    transform: rotate(360deg);
-  }
 }
 
 .bx--inline-notification__text-wrapper p {

--- a/src/lib-components/NsInlineNotification.vue
+++ b/src/lib-components/NsInlineNotification.vue
@@ -60,8 +60,7 @@
         `${carbonPrefix}--btn`,
         `${carbonPrefix}--btn--sm`,
         `${carbonPrefix}--btn--ghost`,
-        'action-button',
-        { 'action-button--loading': loadingAction }
+        'action-button'
       ]"
       type="button"
     >
@@ -135,11 +134,6 @@ export default {
 
 .action-button {
   margin-right: 0.5rem;
-}
-
-.action-button--loading {
-  cursor: not-allowed;
-  opacity: 0.7;
 }
 
 .action-button__loader {

--- a/src/lib-components/NsInlineNotification.vue
+++ b/src/lib-components/NsInlineNotification.vue
@@ -54,15 +54,18 @@
     <button
       v-if="actionLabel"
       @click="$emit('action')"
+      :disabled="loadingAction"
       :class="[
         `${carbonPrefix}--inline-notification__action-button`,
         `${carbonPrefix}--btn`,
         `${carbonPrefix}--btn--sm`,
         `${carbonPrefix}--btn--ghost`,
-        'action-button'
+        'action-button',
+        { 'action-button--loading': loadingAction }
       ]"
       type="button"
     >
+      <span v-if="loadingAction" class="action-button__loader"></span>
       {{ actionLabel }}
     </button>
     <button
@@ -107,6 +110,10 @@ export default {
       type: Boolean,
       default: false
     },
+    loadingAction: {
+      type: Boolean,
+      default: false
+    },
     timer: {
       type: Number
     }
@@ -128,6 +135,29 @@ export default {
 
 .action-button {
   margin-right: 0.5rem;
+}
+
+.action-button--loading {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.action-button__loader {
+  display: inline-block;
+  width: 0.875rem;
+  height: 0.875rem;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: ns-spin 0.6s linear infinite;
+  margin-right: 0.4rem;
+  vertical-align: middle;
+}
+
+@keyframes ns-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .bx--inline-notification__text-wrapper p {

--- a/src/lib-components/NsInlineNotification.vue
+++ b/src/lib-components/NsInlineNotification.vue
@@ -57,6 +57,7 @@
       :loading="loadingAction"
       kind="ghost"
       size="sm"
+      type="button"
       :class="[
         `${carbonPrefix}--inline-notification__action-button`,
         'action-button'


### PR DESCRIPTION
This pull request updates the `NsInlineNotification` component to improve the action button's usability and consistency. The main change is replacing the native `<button>` with the custom `NsButton` component, which introduces support for a loading state and ensures consistent styling.

**Component enhancements:**

* Replaced the native `<button>` for the action with the `NsButton` component, adding support for the `loadingAction` prop to display a loading indicator, and ensuring consistent size and style (`kind="ghost"`, `size="sm"`).
* Added the `loadingAction` prop to the component, allowing parent components to control the loading state of the action button.

**Dependency updates:**

* Registered `NsButton` as a component dependency in `NsInlineNotification`.