### PR TITLE
Add NetworkPictogram

### DIFF
--- a/src/lib-components/index.js
+++ b/src/lib-components/index.js
@@ -60,6 +60,7 @@ export { default as DocumentSecurityPictogram } from "./pictograms/DocumentSecur
 export { default as CircleCheckPictogram } from "./pictograms/CircleCheckPictogram.vue";
 export { default as AppsPictogram } from "./pictograms/AppsPictogram.vue";
 export { default as ServerRackPictogram } from "./pictograms/ServerRackPictogram.vue";
+export { default as NetworkPictogram } from "./pictograms/NetworkPictogram.vue";
 
 // Mixins
 export { default as UtilService } from "../lib-mixins/util.js";

--- a/src/lib-components/pictograms/NetworkPictogram.vue
+++ b/src/lib-components/pictograms/NetworkPictogram.vue
@@ -1,0 +1,14 @@
+<!--
+  Copyright (C) 2026 Nethesis S.r.l.
+  SPDX-License-Identifier: GPL-3.0-or-later
+-->
+<template>
+  <path
+    id="network--3"
+    d="M30,30H22V22h8Zm-6-2h4V24H24Z
+	M20,27H8A6,6,0,0,1,8,15h2v2H8a4,4,0,0,0,0,8H20Z
+	M20,20H12V12h8Zm-6-2h4V14H14Z
+	M24,17H22V15h2a4,4,0,0,0,0-8H12V5H24a6,6,0,0,1,0,12Z
+	M10,10H2V2h8ZM4,8H8V4H4Z"
+  />
+</template>


### PR DESCRIPTION
## Description

Adds a `NetworkPictogram`, the subpaths of the Carbon `network--3` icon, for empty states about network configuration.

NethServer/ns8-core#1258 needs it for the empty state of the frontend proxies table, and carries a local copy under `core/ui/src/components/` in the meantime. Once this is released and the dependency bumped in core, that copy goes away and the import comes from here, next to the other fifteen pictograms.

## Changes

- `src/lib-components/pictograms/NetworkPictogram.vue`, template only and with the Carbon icon id kept, as the sibling pictograms do
- one export line in `src/lib-components/index.js`, at the end of the `// Pictograms` section

No version bump: releases are their own commit in this repo.

## Testing

`npm ci && npm run build` with `NODE_OPTIONS=--openssl-legacy-provider`, the same steps as `ci.yml`. The build passes and `NetworkPictogram` is present in `dist/ns8-ui-lib.esm.js`.

Rendering was checked in core through `<NsEmptyState>`, where `NsPictogram` provides the svg wrapper and the pictogram only supplies the paths:

```html
<template #pictogram>
  <NetworkPictogram />
</template>
```
